### PR TITLE
Update ESI URL

### DIFF
--- a/src/AppBundle/Command/UpdateSDECommand.php
+++ b/src/AppBundle/Command/UpdateSDECommand.php
@@ -135,7 +135,7 @@ class UpdateSDECommand extends ContainerAwareCommand
 
             $bar->finish();
 			
-			/*$prices = json_decode(file_get_contents("https://esi.tech.ccp.is/latest/insurance/prices/?datasource=tranquility&language=en-us"), true);
+			/*$prices = json_decode(file_get_contents("https://esi.evetech.net/latest/insurance/prices/?datasource=tranquility&language=en-us"), true);
 			if(isset($prices[0]['levels'])) {
 				
 				$database = $this->getContainer()->getParameter('database_name');

--- a/src/AppBundle/ESI/ESI.php
+++ b/src/AppBundle/ESI/ESI.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class ESI
 {
-    const ESI_URL = 'https://esi.tech.ccp.is';
+    const ESI_URL = 'https://esi.evetech.net';
     const SEARCH = '/v1/search/';
     const ALLIANCE_NAMES = '/v2/universe/names/';
     const CORPORATION_NAMES = '/v2/universe/names/';

--- a/src/AppBundle/Utilities/ESI.php
+++ b/src/AppBundle/Utilities/ESI.php
@@ -13,7 +13,7 @@ use AppBundle\Model\Character;
 
 class ESI
 {
-    private static $ESI_URI = 'https://esi.tech.ccp.is';
+    private static $ESI_URI = 'https://esi.evetech.net';
     private static $defaultTimeout = 10.0;
 
 


### PR DESCRIPTION
As per https://developers.eveonline.com/blog/article/removal-of-redirect-from-.tech.ccp.is-on-jan-7th

esi.tech.ccp.is URL is being removed, esi.evetech.net will continue to operate as its replacement